### PR TITLE
Fixed error like issue #1 and substring expansion

### DIFF
--- a/etc/init.d/hubic
+++ b/etc/init.d/hubic
@@ -60,7 +60,7 @@ add_exclusions()
 {
         if [ -n "$EXCLUSIONS_PATH" ]; then
         	while read  -r exclusion; do
-			if [[ -n "$exclusion" && ${exclusion::1} != "#" ]]; then
+			if [ -n "$exclusion" ] && [ ${exclusion::1} != "#" ]; then
 				do_exec exclude add "$SYNC_DIR/$exclusion"
 			fi
 		done < "$EXCLUSIONS_PATH"

--- a/etc/init.d/hubic
+++ b/etc/init.d/hubic
@@ -60,7 +60,7 @@ add_exclusions()
 {
         if [ -n "$EXCLUSIONS_PATH" ]; then
         	while read  -r exclusion; do
-			if [ -n "$exclusion" ] && [ ${exclusion::1} != "#" ]; then
+			if [ -n "`echo "$exclusion" |grep -v "^\s*#"`" ]; then
 				do_exec exclude add "$SYNC_DIR/$exclusion"
 			fi
 		done < "$EXCLUSIONS_PATH"


### PR DESCRIPTION
Error in init script for Ubuntu 13.10 that use dash like sh implementation. Also permit blank spaces before comments.
